### PR TITLE
Fix/rodi query and data consistency

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,15 @@
 RODI benchmark distribution, version 2.1
 ========================================
 
+2.1 (community update, May 2026)
+--------------------------------
++ fixed additional inconsistencies in query definitions and initialization data
+  - conferences_noFks / conferences_renamed / conferences_structured:
+    * corrected query pairs where SQL COUNT(*) was compared with SPARQL value lists
+  - cmt_structured:
+    * added missing data tuples to satisfy inclusion dependencies required for query Q12
+
+
 2.1 (community update, Feb 2026)
 --------------------------------
 + fixed several small inconsistencies across scenario files to align SQL schemas, SPARQL queries, ontology terms, and initialization data

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ _RODI: Benchmarking Relational-to-Ontology Mapping Generation Quality_.  Semanti
 
 ## Version Notes
 
-As of version 2.1 (February 2026), some scenario files have been updated to fix small
+As of version 2.1 (February–May 2026), some scenario files have been updated to fix small
 inconsistencies and to better align SQL schemas, SPARQL queries, and ontology terms.
 Some naming differences and denormalization details were adjusted so that all evaluation
 queries run correctly across scenarios.

--- a/data/cmt_structured/dump.sql
+++ b/data/cmt_structured/dump.sql
@@ -3304,6 +3304,12 @@ COPY "ProgramCommitteeMember" ("ID", "maxPapers", "addedBy") FROM stdin;
 637	\N	\N
 393	\N	\N
 1089	\N	\N
+1034	\N	\N
+678	\N	\N
+535	\N	\N
+24	\N	\N
+473	\N	\N
+200	\N	\N
 \.
 
 

--- a/data/conference_nofks/queries/Q50.qpair
+++ b/data/conference_nofks/queries/Q50.qpair
@@ -7,7 +7,7 @@ sql=SELECT COUNT(*) \n\
 
 sparql=prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \n\
 prefix : <http://conference#> \n\
-SELECT ?pNme ?absTxt \n\
+SELECT (COUNT(?p) AS ?count) \n\
 	WHERE {?p rdf:type :Paper; \n\
 		:has_an_abstract ?abs . \n\
 		?abs rdf:type :Abstract }

--- a/data/conference_renamed/queries/Q50.qpair
+++ b/data/conference_renamed/queries/Q50.qpair
@@ -7,7 +7,7 @@ sql=SELECT COUNT(*) \n\
 
 sparql=prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \n\
 prefix : <http://conference#> \n\
-SELECT ?pNme ?absTxt \n\
+SELECT (COUNT(?p) AS ?count) \n\
 	WHERE {?p rdf:type :Paper; \n\
 		:has_an_abstract ?abs . \n\
 		?abs rdf:type :Abstract }

--- a/data/conference_structured/queries/Q50.qpair
+++ b/data/conference_structured/queries/Q50.qpair
@@ -7,7 +7,7 @@ sql=SELECT COUNT(*) \n\
 
 sparql=prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> \n\
 prefix : <http://conference#> \n\
-SELECT ?pNme ?absTxt \n\
+SELECT (COUNT(?p) AS ?count) \n\
 	WHERE {?p rdf:type :Paper; \n\
 		:has_an_abstract ?abs . \n\
 		?abs rdf:type :Abstract }


### PR DESCRIPTION
Hi Christoph,

as discussed, this PR contains a second set of fixes I identified while continuing to use the default RODI scenarios for my Master’s thesis evaluation pipeline. Following your feedback, I did not include any foreign key additions and focused only on query and data consistency.

I addressed two issues:

Query inconsistencies (conference scenarios)
I found three query pairs where an SQL COUNT(*) result is compared against a SPARQL query returning a list of values. Since these result types are not comparable, the queries cannot be satisfied simultaneously.
These queries are shared across scenarios using the same ontology (e.g., conferences_noFks, conferences_renamed, conferences_structured), so I corrected them in all three scenarios.

Data inconsistency in cmt_structured (Q12)
In cmt_structured, the relation hasProgramCommitteeMember contains values that are not fully reflected in the ProgramCommitteeMember table (i.e., the inclusion dependency does not hold).
When both tables are mapped to individuals of type :ProgramCommitteeMember, hasProgramCommitteeMember yields additional instances of ProgramCommitteeMember that are not counted by the SQL baseline (SELECT COUNT(*) FROM "ProgramCommitteeMember"), leading to a mismatch in query Q12 of this scenario. In the other scenarios cmt_renamed and cmt_denormalized this inclusion dependency holds.
To resolve this, I added the missing tuples to ProgramCommitteeMember so that the inclusion dependency holds and the SQL/SPARQL comparison becomes consistent.

I added the following changelog entry:

2.1 (community update, May 2026)
--------------------------------
+ fixed additional inconsistencies in query definitions and initialization data
  - conferences_noFks / conferences_renamed / conferences_structured:
    * corrected query pairs where SQL COUNT(*) was compared with SPARQL value lists
  - cmt_structured:
    * added missing data tuples to satisfy inclusion dependencies required for query Q12

Please let me know if this looks good to you or if you’d prefer a different approach.

Best regards

Florian